### PR TITLE
Add department modal

### DIFF
--- a/OpenTalk_FE/src/components/DepartmentFormModal.jsx
+++ b/OpenTalk_FE/src/components/DepartmentFormModal.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Form,
+  FormGroup,
+  Label,
+  Input,
+  Button,
+} from 'reactstrap';
+
+const DepartmentFormModal = ({ isOpen, toggle, onSubmit, initialData }) => {
+  const [departmentName, setDepartmentName] = useState('');
+
+  useEffect(() => {
+    setDepartmentName(initialData?.departmentName || initialData?.name || '');
+  }, [initialData]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit({ departmentName });
+  };
+
+  return (
+    <Modal isOpen={isOpen} toggle={toggle} centered>
+      <Form onSubmit={handleSubmit}>
+        <ModalHeader toggle={toggle}>
+          {initialData ? 'Edit Department' : 'Add Department'}
+        </ModalHeader>
+        <ModalBody>
+          <FormGroup>
+            <Label for="departmentName">Department Name</Label>
+            <Input
+              id="departmentName"
+              name="departmentName"
+              value={departmentName}
+              onChange={(e) => setDepartmentName(e.target.value)}
+              required
+            />
+          </FormGroup>
+        </ModalBody>
+        <ModalFooter>
+          <Button color="secondary" onClick={toggle} type="button">
+            Cancel
+          </Button>
+          <Button color="primary" type="submit">
+            {initialData ? 'Edit' : 'Add'}
+          </Button>
+        </ModalFooter>
+      </Form>
+    </Modal>
+  );
+};
+
+export default DepartmentFormModal;

--- a/OpenTalk_FE/src/pages/ListDepartments.jsx
+++ b/OpenTalk_FE/src/pages/ListDepartments.jsx
@@ -1,16 +1,38 @@
 import React, { useState } from 'react';
 import { Table, Button } from 'reactstrap';
 import { useParams } from 'react-router-dom';
+import DepartmentFormModal from '../components/DepartmentFormModal';
 
 const ListDepartments = () => {
   const { companyId, branchId } = useParams();
   const [departments, setDepartments] = useState([]);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selected, setSelected] = useState(null);
+
+  const handleCreate = async (payload) => {
+    // TODO: call API
+    setModalOpen(false);
+  };
+
+  const handleUpdate = async (payload) => {
+    // TODO: call API
+    setModalOpen(false);
+    setSelected(null);
+  };
 
   return (
     <div className="container-fluid">
       <div className="d-flex justify-content-between align-items-center mb-3">
         <h2>Departments</h2>
-        <Button color="primary">Add Department</Button>
+        <Button
+          color="primary"
+          onClick={() => {
+            setSelected(null);
+            setModalOpen(true);
+          }}
+        >
+          Add Department
+        </Button>
       </div>
       <Table bordered hover>
         <thead className="table-light">
@@ -28,7 +50,16 @@ const ListDepartments = () => {
               <td>{d.head}</td>
               <td>{d.totalEmployees}</td>
               <td className="d-flex gap-1">
-                <Button size="sm" color="secondary">Edit</Button>
+                <Button
+                  size="sm"
+                  color="secondary"
+                  onClick={() => {
+                    setSelected(d);
+                    setModalOpen(true);
+                  }}
+                >
+                  Edit
+                </Button>
                 <Button size="sm" color="info">View Employees</Button>
                 <Button size="sm" color="danger">Delete</Button>
               </td>
@@ -36,6 +67,15 @@ const ListDepartments = () => {
           ))}
         </tbody>
       </Table>
+      <DepartmentFormModal
+        isOpen={modalOpen}
+        toggle={() => {
+          setModalOpen(false);
+          setSelected(null);
+        }}
+        onSubmit={selected ? handleUpdate : handleCreate}
+        initialData={selected}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- implement `DepartmentFormModal` for department creation/editing
- integrate department form modal into `ListDepartments` page

## Testing
- `npm run lint` *(fails: 145 problems)*

------
https://chatgpt.com/codex/tasks/task_e_686fe2982468832b956089313043ceca