### PR TITLE
[Feature] Meeting - grid layout and api fetch

### DIFF
--- a/OpenTalk_FE/src/api/meeting.js
+++ b/OpenTalk_FE/src/api/meeting.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+const API_BASE = 'http://localhost:8080/api/opentalk-topic';
+
+export const getMeetings = () =>
+  axios.get(API_BASE).then(res => res.data);

--- a/OpenTalk_FE/src/pages/MeetingListPage.jsx
+++ b/OpenTalk_FE/src/pages/MeetingListPage.jsx
@@ -1,4 +1,7 @@
+import { useEffect, useState } from 'react';
 import MeetingCard from '../components/meetingCard/MeetingCard';
+import { getMeetings } from '../api/meeting';
+import './styles/MeetingListPage.css';
 
 const mockMeetings = [
   { id: 1, topicName: 'Weekly Sync', scheduledDate: '2025-07-14 10:00', meetingLink: 'https://meeting.com/1' },
@@ -24,7 +27,21 @@ const mockMeetings = [
 ];
 
 const MeetingListPage = () => {
-  const meetings = mockMeetings;
+  const [meetings, setMeetings] = useState(mockMeetings);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getMeetings();
+        setMeetings(Array.isArray(data) ? data : mockMeetings);
+      } catch (e) {
+        console.error(e);
+        setMeetings(mockMeetings);
+      }
+    };
+
+    fetchData();
+  }, []);
 
   const handleJoin = (link) => {
     if (link) {
@@ -33,7 +50,7 @@ const MeetingListPage = () => {
   };
 
   return (
-    <div style={{ padding: '20px', display: 'flex', flexWrap: 'wrap', gap: '20px' }}>
+    <div className="meeting-list-container">
       {meetings.map((m) => (
         <MeetingCard
           key={m.id}
@@ -50,4 +67,3 @@ const MeetingListPage = () => {
 };
 
 export default MeetingListPage;
-

--- a/OpenTalk_FE/src/pages/styles/MeetingListPage.css
+++ b/OpenTalk_FE/src/pages/styles/MeetingListPage.css
@@ -1,0 +1,6 @@
+.meeting-list-container {
+    padding: 20px;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 20px;
+}


### PR DESCRIPTION
## Summary
- fetch meeting list from backend
- show meeting cards in a 4-column grid
- keep mock meeting data as fallback
- revert unintended meeting card width change

## Testing
- `npm run lint` *(fails: many lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_6871ef301274832b87a82d83c91c7176