### PR TITLE
Add meeting detail page

### DIFF
--- a/OpenTalk_FE/src/App.jsx
+++ b/OpenTalk_FE/src/App.jsx
@@ -4,6 +4,7 @@ import Layout from "./layouts/MainLayout";
 import MeetingList from "./pages/test.jsx";
 import SuggestTopic from "./pages/SuggestTopic.jsx";
 import MeetingListPage from "./pages/MeetingListPage.jsx";
+import MeetingDetailPage from "./pages/MeetingDetailPage.jsx";
 import CustomTextEditor from "./components/textEdit/RichTextEditor.jsx";
 import TiptapEditor from "./components/textEdit/TiptapEditor.jsx"; // đường dẫn tùy bạn
 import OrganizationListPage from "./pages/OrganizationListPage.jsx";
@@ -54,6 +55,7 @@ function App() {
                 <Routes>
                     <Route path="/" element={<Overview />} />
                     <Route path="/meeting" element={<Meeting />} />
+                    <Route path="/meeting/:id" element={<MeetingDetailPage />} />
                     <Route path="/message" element={<Message />} />
                     <Route path="/project" element={<Project />} />
                     <Route path="/ticket" element={<Ticket />} />

--- a/OpenTalk_FE/src/api/meeting.js
+++ b/OpenTalk_FE/src/api/meeting.js
@@ -4,3 +4,6 @@ const API_BASE = 'http://localhost:8080/api/opentalk-topic';
 
 export const getMeetings = () =>
   axios.get(API_BASE).then(res => res.data);
+
+export const getMeetingById = (id) =>
+  axios.get(`${API_BASE}/${id}`).then(res => res.data);

--- a/OpenTalk_FE/src/components/meetingCard/MeetingCard.css
+++ b/OpenTalk_FE/src/components/meetingCard/MeetingCard.css
@@ -5,6 +5,7 @@
     box-shadow: 0 0 15px rgba(0,0,0,0.1);
     width: 300px;
     font-family: Arial, sans-serif;
+    cursor: pointer;
 }
 
 .meeting-icon {

--- a/OpenTalk_FE/src/components/meetingCard/MeetingCard.jsx
+++ b/OpenTalk_FE/src/components/meetingCard/MeetingCard.jsx
@@ -7,10 +7,11 @@ const MeetingCard = ({
                          description,
                          participants,
                          extraCount,
-                         onJoin
+                         onJoin,
+                         onView
                      }) => {
     return (
-        <div className="meeting-card">
+        <div className="meeting-card" onClick={onView}>
             <div className="meeting-icon">
                 <span role="img" aria-label="video">📹</span>
             </div>
@@ -27,7 +28,7 @@ const MeetingCard = ({
                 {extraCount > 0 && <div className="extra-count">+{extraCount}</div>}
             </div>
 
-            <button className="join-button" onClick={onJoin}>Join Meeting</button>
+            <button className="join-button" onClick={(e) => { e.stopPropagation(); onJoin(); }}>Join Meeting</button>
         </div>
     );
 };

--- a/OpenTalk_FE/src/pages/MeetingDetailPage.jsx
+++ b/OpenTalk_FE/src/pages/MeetingDetailPage.jsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { FaArrowLeft } from 'react-icons/fa';
+import { getMeetingById } from '../api/meeting';
+import './styles/MeetingDetailPage.css';
+
+const mockMeeting = {
+  id: 0,
+  topicName: '',
+  scheduledDate: '',
+  meetingLink: '',
+  branchName: '',
+  status: ''
+};
+
+const MeetingDetailPage = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [meeting, setMeeting] = useState(null);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const data = await getMeetingById(id);
+        setMeeting(data);
+      } catch (e) {
+        console.error(e);
+        setMeeting(mockMeeting);
+      }
+    };
+    loadData();
+  }, [id]);
+
+  if (!meeting) return <div className="meeting-detail-page" />;
+
+  return (
+    <div className="meeting-detail-page">
+      <div className="page-header">
+        <button onClick={() => navigate('/meeting')} className="back-button">
+          <FaArrowLeft size={16} />
+        </button>
+        <h1 className="page-title">{meeting.topicName || meeting.meetingName}</h1>
+      </div>
+
+      <div className="detail-card">
+        <div className="detail-row">
+          <span className="label">Scheduled Date:</span>
+          <span className="value">{meeting.scheduledDate}</span>
+        </div>
+        {meeting.branchName && (
+          <div className="detail-row">
+            <span className="label">Branch:</span>
+            <span className="value">{meeting.branchName}</span>
+          </div>
+        )}
+        {meeting.meetingLink && (
+          <div className="detail-row">
+            <span className="label">Meeting Link:</span>
+            <a
+              href={meeting.meetingLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="value link"
+            >
+              {meeting.meetingLink}
+            </a>
+          </div>
+        )}
+        {meeting.status !== undefined && (
+          <div className="detail-row">
+            <span className="label">Status:</span>
+            <span className="value">{meeting.status || (meeting.isEnabled ? 'Enabled' : 'Disabled')}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MeetingDetailPage;

--- a/OpenTalk_FE/src/pages/MeetingListPage.jsx
+++ b/OpenTalk_FE/src/pages/MeetingListPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import MeetingCard from '../components/meetingCard/MeetingCard';
 import { FaSearch, FaChevronDown, FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 import { getMeetings } from '../api/meeting';
@@ -36,6 +37,7 @@ const mockBranches = [
 ];
 
 const MeetingListPage = () => {
+  const navigate = useNavigate();
   const [meetings, setMeetings] = useState(mockMeetings);
   const [branches, setBranches] = useState(mockBranches);
   const [searchTerm, setSearchTerm] = useState('');
@@ -127,6 +129,7 @@ const MeetingListPage = () => {
             participants={[]}
             extraCount={0}
             onJoin={() => handleJoin(m.meetingLink)}
+            onView={() => navigate(`/meeting/${m.id}`)}
           />
         ))}
       </div>

--- a/OpenTalk_FE/src/pages/styles/MeetingDetailPage.css
+++ b/OpenTalk_FE/src/pages/styles/MeetingDetailPage.css
@@ -1,0 +1,64 @@
+.meeting-detail-page {
+    padding: 24px;
+    background-color: #f9fafb;
+    min-height: 100vh;
+}
+
+.page-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.back-button {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 1px solid #e5e7eb;
+    background: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    margin-right: 16px;
+    transition: all 0.2s;
+}
+
+.back-button:hover {
+    background-color: #f3f4f6;
+}
+
+.page-title {
+    font-size: 24px;
+    font-weight: bold;
+    color: #111827;
+    margin: 0;
+}
+
+.detail-card {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    padding: 24px;
+    max-width: 600px;
+}
+
+.detail-row {
+    display: flex;
+    margin-bottom: 12px;
+}
+
+.label {
+    width: 140px;
+    font-weight: 500;
+    color: #6b7280;
+}
+
+.value {
+    color: #111827;
+}
+
+.link {
+    color: #0369a1;
+    text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- create a MeetingDetailPage and style for showing meeting info
- allow navigation from meeting cards to the detail page
- make meeting cards clickable and prevent click on join button
- expose API to get meeting by id
- register the new route

## Testing
- `npm run lint` *(fails: many errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_687268960d44832ba0be923f4ef85803