### PR TITLE
Update meeting pages with new data structure

### DIFF
--- a/OpenTalk_FE/src/components/meetingCard/MeetingCard.jsx
+++ b/OpenTalk_FE/src/components/meetingCard/MeetingCard.jsx
@@ -2,14 +2,16 @@ import React from "react";
 import "./MeetingCard.css";
 
 const MeetingCard = ({
-                         title,
-                         time,
-                         description,
-                         participants,
-                         extraCount,
-                         onJoin,
-                         onView
-                     }) => {
+    title,
+    time,
+    description,
+    participants,
+    extraCount,
+    actionLabel = 'Join Meeting',
+    onAction,
+    showButton = true,
+    onView,
+}) => {
     return (
         <div className="meeting-card" onClick={onView}>
             <div className="meeting-icon">
@@ -28,7 +30,17 @@ const MeetingCard = ({
                 {extraCount > 0 && <div className="extra-count">+{extraCount}</div>}
             </div>
 
-            <button className="join-button" onClick={(e) => { e.stopPropagation(); onJoin(); }}>Join Meeting</button>
+            {showButton && (
+                <button
+                    className="join-button"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        if (onAction) onAction();
+                    }}
+                >
+                    {actionLabel}
+                </button>
+            )}
         </div>
     );
 };

--- a/OpenTalk_FE/src/mock/MeetingMockData.js
+++ b/OpenTalk_FE/src/mock/MeetingMockData.js
@@ -1,0 +1,3763 @@
+export const meetingMockData = [
+  {
+    "id": 1,
+    "meetingName": "Planning 1",
+    "scheduledDate": "2025-07-15",
+    "meetingLink": "https://meeting.com/1",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 1",
+      "description": "Description 1",
+      "remark": "Remark 1",
+      "suggestBy": {
+        "fullName": "Bob 301",
+        "email": "user301@example.com",
+        "username": "user301",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Bob 401",
+        "email": "user401@example.com",
+        "username": "user401",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Bob 201",
+        "email": "user201@example.com",
+        "username": "user201",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 2,
+    "meetingName": "Review 2",
+    "scheduledDate": "2025-07-17",
+    "meetingLink": "https://meeting.com/2",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 2",
+      "description": "Description 2",
+      "remark": "Remark 2",
+      "suggestBy": {
+        "fullName": "Carol 302",
+        "email": "user302@example.com",
+        "username": "user302",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Carol 402",
+        "email": "user402@example.com",
+        "username": "user402",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Carol 202",
+        "email": "user202@example.com",
+        "username": "user202",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 3,
+    "meetingName": "Sync 3",
+    "scheduledDate": "2025-07-19",
+    "meetingLink": "https://meeting.com/3",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 3",
+      "description": "Description 3",
+      "remark": "Remark 3",
+      "suggestBy": {
+        "fullName": "Dave 303",
+        "email": "user303@example.com",
+        "username": "user303",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Dave 403",
+        "email": "user403@example.com",
+        "username": "user403",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Dave 203",
+        "email": "user203@example.com",
+        "username": "user203",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 4,
+    "meetingName": "Update 4",
+    "scheduledDate": "2025-07-21",
+    "meetingLink": "https://meeting.com/4",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 4",
+      "description": "Description 4",
+      "remark": "Remark 4",
+      "suggestBy": {
+        "fullName": "Eve 304",
+        "email": "user304@example.com",
+        "username": "user304",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Eve 404",
+        "email": "user404@example.com",
+        "username": "user404",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Eve 204",
+        "email": "user204@example.com",
+        "username": "user204",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 5,
+    "meetingName": "Discussion 5",
+    "scheduledDate": "2025-07-23",
+    "meetingLink": "https://meeting.com/5",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 5",
+      "description": "Description 5",
+      "remark": "Remark 5",
+      "suggestBy": {
+        "fullName": "Frank 305",
+        "email": "user305@example.com",
+        "username": "user305",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Frank 405",
+        "email": "user405@example.com",
+        "username": "user405",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Frank 205",
+        "email": "user205@example.com",
+        "username": "user205",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 6,
+    "meetingName": "Planning 6",
+    "scheduledDate": "2025-07-25",
+    "meetingLink": "https://meeting.com/6",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 6",
+      "description": "Description 6",
+      "remark": "Remark 6",
+      "suggestBy": {
+        "fullName": "Grace 306",
+        "email": "user306@example.com",
+        "username": "user306",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Grace 406",
+        "email": "user406@example.com",
+        "username": "user406",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Grace 206",
+        "email": "user206@example.com",
+        "username": "user206",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 7,
+    "meetingName": "Review 7",
+    "scheduledDate": "2025-07-27",
+    "meetingLink": "https://meeting.com/7",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 7",
+      "description": "Description 7",
+      "remark": "Remark 7",
+      "suggestBy": {
+        "fullName": "Hank 307",
+        "email": "user307@example.com",
+        "username": "user307",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Hank 407",
+        "email": "user407@example.com",
+        "username": "user407",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Hank 207",
+        "email": "user207@example.com",
+        "username": "user207",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 8,
+    "meetingName": "Sync 8",
+    "scheduledDate": "2025-07-29",
+    "meetingLink": "https://meeting.com/8",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 8",
+      "description": "Description 8",
+      "remark": "Remark 8",
+      "suggestBy": {
+        "fullName": "Ivy 308",
+        "email": "user308@example.com",
+        "username": "user308",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Ivy 408",
+        "email": "user408@example.com",
+        "username": "user408",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Ivy 208",
+        "email": "user208@example.com",
+        "username": "user208",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 9,
+    "meetingName": "Update 9",
+    "scheduledDate": "2025-07-31",
+    "meetingLink": "https://meeting.com/9",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 9",
+      "description": "Description 9",
+      "remark": "Remark 9",
+      "suggestBy": {
+        "fullName": "Jack 309",
+        "email": "user309@example.com",
+        "username": "user309",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Jack 409",
+        "email": "user409@example.com",
+        "username": "user409",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Jack 209",
+        "email": "user209@example.com",
+        "username": "user209",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 10,
+    "meetingName": "Discussion 10",
+    "scheduledDate": "2025-08-02",
+    "meetingLink": "https://meeting.com/10",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 10",
+      "description": "Description 10",
+      "remark": "Remark 10",
+      "suggestBy": {
+        "fullName": "Alice 310",
+        "email": "user310@example.com",
+        "username": "user310",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Alice 410",
+        "email": "user410@example.com",
+        "username": "user410",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Alice 210",
+        "email": "user210@example.com",
+        "username": "user210",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 11,
+    "meetingName": "Planning 11",
+    "scheduledDate": "2025-08-04",
+    "meetingLink": "https://meeting.com/11",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 11",
+      "description": "Description 11",
+      "remark": "Remark 11",
+      "suggestBy": {
+        "fullName": "Bob 311",
+        "email": "user311@example.com",
+        "username": "user311",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Bob 411",
+        "email": "user411@example.com",
+        "username": "user411",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Bob 211",
+        "email": "user211@example.com",
+        "username": "user211",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 12,
+    "meetingName": "Review 12",
+    "scheduledDate": "2025-08-06",
+    "meetingLink": "https://meeting.com/12",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 12",
+      "description": "Description 12",
+      "remark": "Remark 12",
+      "suggestBy": {
+        "fullName": "Carol 312",
+        "email": "user312@example.com",
+        "username": "user312",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Carol 412",
+        "email": "user412@example.com",
+        "username": "user412",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Carol 212",
+        "email": "user212@example.com",
+        "username": "user212",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 13,
+    "meetingName": "Sync 13",
+    "scheduledDate": "2025-08-08",
+    "meetingLink": "https://meeting.com/13",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 13",
+      "description": "Description 13",
+      "remark": "Remark 13",
+      "suggestBy": {
+        "fullName": "Dave 313",
+        "email": "user313@example.com",
+        "username": "user313",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Dave 413",
+        "email": "user413@example.com",
+        "username": "user413",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Dave 213",
+        "email": "user213@example.com",
+        "username": "user213",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 14,
+    "meetingName": "Update 14",
+    "scheduledDate": "2025-08-10",
+    "meetingLink": "https://meeting.com/14",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 14",
+      "description": "Description 14",
+      "remark": "Remark 14",
+      "suggestBy": {
+        "fullName": "Eve 314",
+        "email": "user314@example.com",
+        "username": "user314",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Eve 414",
+        "email": "user414@example.com",
+        "username": "user414",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Eve 214",
+        "email": "user214@example.com",
+        "username": "user214",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 15,
+    "meetingName": "Discussion 15",
+    "scheduledDate": "2025-08-12",
+    "meetingLink": "https://meeting.com/15",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 15",
+      "description": "Description 15",
+      "remark": "Remark 15",
+      "suggestBy": {
+        "fullName": "Frank 315",
+        "email": "user315@example.com",
+        "username": "user315",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Frank 415",
+        "email": "user415@example.com",
+        "username": "user415",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Frank 215",
+        "email": "user215@example.com",
+        "username": "user215",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 16,
+    "meetingName": "Planning 16",
+    "scheduledDate": "2025-08-14",
+    "meetingLink": "https://meeting.com/16",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 16",
+      "description": "Description 16",
+      "remark": "Remark 16",
+      "suggestBy": {
+        "fullName": "Grace 316",
+        "email": "user316@example.com",
+        "username": "user316",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Grace 416",
+        "email": "user416@example.com",
+        "username": "user416",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Grace 216",
+        "email": "user216@example.com",
+        "username": "user216",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 17,
+    "meetingName": "Review 17",
+    "scheduledDate": "2025-08-16",
+    "meetingLink": "https://meeting.com/17",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 17",
+      "description": "Description 17",
+      "remark": "Remark 17",
+      "suggestBy": {
+        "fullName": "Hank 317",
+        "email": "user317@example.com",
+        "username": "user317",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Hank 417",
+        "email": "user417@example.com",
+        "username": "user417",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Hank 217",
+        "email": "user217@example.com",
+        "username": "user217",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 18,
+    "meetingName": "Sync 18",
+    "scheduledDate": "2025-08-18",
+    "meetingLink": "https://meeting.com/18",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 18",
+      "description": "Description 18",
+      "remark": "Remark 18",
+      "suggestBy": {
+        "fullName": "Ivy 318",
+        "email": "user318@example.com",
+        "username": "user318",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Ivy 418",
+        "email": "user418@example.com",
+        "username": "user418",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Ivy 218",
+        "email": "user218@example.com",
+        "username": "user218",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 19,
+    "meetingName": "Update 19",
+    "scheduledDate": "2025-08-20",
+    "meetingLink": "https://meeting.com/19",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 19",
+      "description": "Description 19",
+      "remark": "Remark 19",
+      "suggestBy": {
+        "fullName": "Jack 319",
+        "email": "user319@example.com",
+        "username": "user319",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Jack 419",
+        "email": "user419@example.com",
+        "username": "user419",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Jack 219",
+        "email": "user219@example.com",
+        "username": "user219",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 20,
+    "meetingName": "Discussion 20",
+    "scheduledDate": "2025-08-22",
+    "meetingLink": "https://meeting.com/20",
+    "status": "inactive",
+    "topic": {
+      "title": "Topic 20",
+      "description": "Description 20",
+      "remark": "Remark 20",
+      "suggestBy": {
+        "fullName": "Alice 320",
+        "email": "user320@example.com",
+        "username": "user320",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Alice 420",
+        "email": "user420@example.com",
+        "username": "user420",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Alice 220",
+        "email": "user220@example.com",
+        "username": "user220",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 21,
+    "meetingName": "Planning 21",
+    "scheduledDate": "2025-06-24",
+    "meetingLink": "https://meeting.com/21",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 21",
+      "description": "Description 21",
+      "remark": "Remark 21",
+      "suggestBy": {
+        "fullName": "Bob 321",
+        "email": "user321@example.com",
+        "username": "user321",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Bob 421",
+        "email": "user421@example.com",
+        "username": "user421",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Bob 221",
+        "email": "user221@example.com",
+        "username": "user221",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 22,
+    "meetingName": "Review 22",
+    "scheduledDate": "2025-06-25",
+    "meetingLink": "https://meeting.com/22",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 22",
+      "description": "Description 22",
+      "remark": "Remark 22",
+      "suggestBy": {
+        "fullName": "Carol 322",
+        "email": "user322@example.com",
+        "username": "user322",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Carol 422",
+        "email": "user422@example.com",
+        "username": "user422",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Carol 222",
+        "email": "user222@example.com",
+        "username": "user222",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 23,
+    "meetingName": "Sync 23",
+    "scheduledDate": "2025-06-26",
+    "meetingLink": "https://meeting.com/23",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 23",
+      "description": "Description 23",
+      "remark": "Remark 23",
+      "suggestBy": {
+        "fullName": "Dave 323",
+        "email": "user323@example.com",
+        "username": "user323",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Dave 423",
+        "email": "user423@example.com",
+        "username": "user423",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Dave 223",
+        "email": "user223@example.com",
+        "username": "user223",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 24,
+    "meetingName": "Update 24",
+    "scheduledDate": "2025-06-27",
+    "meetingLink": "https://meeting.com/24",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 24",
+      "description": "Description 24",
+      "remark": "Remark 24",
+      "suggestBy": {
+        "fullName": "Eve 324",
+        "email": "user324@example.com",
+        "username": "user324",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Eve 424",
+        "email": "user424@example.com",
+        "username": "user424",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Eve 224",
+        "email": "user224@example.com",
+        "username": "user224",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 25,
+    "meetingName": "Discussion 25",
+    "scheduledDate": "2025-06-28",
+    "meetingLink": "https://meeting.com/25",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 25",
+      "description": "Description 25",
+      "remark": "Remark 25",
+      "suggestBy": {
+        "fullName": "Frank 325",
+        "email": "user325@example.com",
+        "username": "user325",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Frank 425",
+        "email": "user425@example.com",
+        "username": "user425",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Frank 225",
+        "email": "user225@example.com",
+        "username": "user225",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 26,
+    "meetingName": "Planning 26",
+    "scheduledDate": "2025-06-29",
+    "meetingLink": "https://meeting.com/26",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 26",
+      "description": "Description 26",
+      "remark": "Remark 26",
+      "suggestBy": {
+        "fullName": "Grace 326",
+        "email": "user326@example.com",
+        "username": "user326",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Grace 426",
+        "email": "user426@example.com",
+        "username": "user426",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Grace 226",
+        "email": "user226@example.com",
+        "username": "user226",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 27,
+    "meetingName": "Review 27",
+    "scheduledDate": "2025-06-30",
+    "meetingLink": "https://meeting.com/27",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 27",
+      "description": "Description 27",
+      "remark": "Remark 27",
+      "suggestBy": {
+        "fullName": "Hank 327",
+        "email": "user327@example.com",
+        "username": "user327",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Hank 427",
+        "email": "user427@example.com",
+        "username": "user427",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Hank 227",
+        "email": "user227@example.com",
+        "username": "user227",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 28,
+    "meetingName": "Sync 28",
+    "scheduledDate": "2025-07-01",
+    "meetingLink": "https://meeting.com/28",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 28",
+      "description": "Description 28",
+      "remark": "Remark 28",
+      "suggestBy": {
+        "fullName": "Ivy 328",
+        "email": "user328@example.com",
+        "username": "user328",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Ivy 428",
+        "email": "user428@example.com",
+        "username": "user428",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Ivy 228",
+        "email": "user228@example.com",
+        "username": "user228",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 29,
+    "meetingName": "Update 29",
+    "scheduledDate": "2025-07-02",
+    "meetingLink": "https://meeting.com/29",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 29",
+      "description": "Description 29",
+      "remark": "Remark 29",
+      "suggestBy": {
+        "fullName": "Jack 329",
+        "email": "user329@example.com",
+        "username": "user329",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Jack 429",
+        "email": "user429@example.com",
+        "username": "user429",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Jack 229",
+        "email": "user229@example.com",
+        "username": "user229",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 30,
+    "meetingName": "Discussion 30",
+    "scheduledDate": "2025-07-03",
+    "meetingLink": "https://meeting.com/30",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 30",
+      "description": "Description 30",
+      "remark": "Remark 30",
+      "suggestBy": {
+        "fullName": "Alice 330",
+        "email": "user330@example.com",
+        "username": "user330",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Alice 430",
+        "email": "user430@example.com",
+        "username": "user430",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Alice 230",
+        "email": "user230@example.com",
+        "username": "user230",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 31,
+    "meetingName": "Planning 31",
+    "scheduledDate": "2025-07-04",
+    "meetingLink": "https://meeting.com/31",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 31",
+      "description": "Description 31",
+      "remark": "Remark 31",
+      "suggestBy": {
+        "fullName": "Bob 331",
+        "email": "user331@example.com",
+        "username": "user331",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Bob 431",
+        "email": "user431@example.com",
+        "username": "user431",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Bob 231",
+        "email": "user231@example.com",
+        "username": "user231",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 32,
+    "meetingName": "Review 32",
+    "scheduledDate": "2025-07-05",
+    "meetingLink": "https://meeting.com/32",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 32",
+      "description": "Description 32",
+      "remark": "Remark 32",
+      "suggestBy": {
+        "fullName": "Carol 332",
+        "email": "user332@example.com",
+        "username": "user332",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Carol 432",
+        "email": "user432@example.com",
+        "username": "user432",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Carol 232",
+        "email": "user232@example.com",
+        "username": "user232",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 33,
+    "meetingName": "Sync 33",
+    "scheduledDate": "2025-07-06",
+    "meetingLink": "https://meeting.com/33",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 33",
+      "description": "Description 33",
+      "remark": "Remark 33",
+      "suggestBy": {
+        "fullName": "Dave 333",
+        "email": "user333@example.com",
+        "username": "user333",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Dave 433",
+        "email": "user433@example.com",
+        "username": "user433",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Dave 233",
+        "email": "user233@example.com",
+        "username": "user233",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 34,
+    "meetingName": "Update 34",
+    "scheduledDate": "2025-07-07",
+    "meetingLink": "https://meeting.com/34",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 34",
+      "description": "Description 34",
+      "remark": "Remark 34",
+      "suggestBy": {
+        "fullName": "Eve 334",
+        "email": "user334@example.com",
+        "username": "user334",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Eve 434",
+        "email": "user434@example.com",
+        "username": "user434",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Eve 234",
+        "email": "user234@example.com",
+        "username": "user234",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 35,
+    "meetingName": "Discussion 35",
+    "scheduledDate": "2025-07-08",
+    "meetingLink": "https://meeting.com/35",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 35",
+      "description": "Description 35",
+      "remark": "Remark 35",
+      "suggestBy": {
+        "fullName": "Frank 335",
+        "email": "user335@example.com",
+        "username": "user335",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Frank 435",
+        "email": "user435@example.com",
+        "username": "user435",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Frank 235",
+        "email": "user235@example.com",
+        "username": "user235",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 36,
+    "meetingName": "Planning 36",
+    "scheduledDate": "2025-07-09",
+    "meetingLink": "https://meeting.com/36",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 36",
+      "description": "Description 36",
+      "remark": "Remark 36",
+      "suggestBy": {
+        "fullName": "Grace 336",
+        "email": "user336@example.com",
+        "username": "user336",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Grace 436",
+        "email": "user436@example.com",
+        "username": "user436",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Grace 236",
+        "email": "user236@example.com",
+        "username": "user236",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 37,
+    "meetingName": "Review 37",
+    "scheduledDate": "2025-07-10",
+    "meetingLink": "https://meeting.com/37",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 37",
+      "description": "Description 37",
+      "remark": "Remark 37",
+      "suggestBy": {
+        "fullName": "Hank 337",
+        "email": "user337@example.com",
+        "username": "user337",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Hank 437",
+        "email": "user437@example.com",
+        "username": "user437",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Hank 237",
+        "email": "user237@example.com",
+        "username": "user237",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 38,
+    "meetingName": "Sync 38",
+    "scheduledDate": "2025-07-11",
+    "meetingLink": "https://meeting.com/38",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 38",
+      "description": "Description 38",
+      "remark": "Remark 38",
+      "suggestBy": {
+        "fullName": "Ivy 338",
+        "email": "user338@example.com",
+        "username": "user338",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Ivy 438",
+        "email": "user438@example.com",
+        "username": "user438",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Ivy 238",
+        "email": "user238@example.com",
+        "username": "user238",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 39,
+    "meetingName": "Update 39",
+    "scheduledDate": "2025-07-12",
+    "meetingLink": "https://meeting.com/39",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 39",
+      "description": "Description 39",
+      "remark": "Remark 39",
+      "suggestBy": {
+        "fullName": "Jack 339",
+        "email": "user339@example.com",
+        "username": "user339",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Jack 439",
+        "email": "user439@example.com",
+        "username": "user439",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Jack 239",
+        "email": "user239@example.com",
+        "username": "user239",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 40,
+    "meetingName": "Discussion 40",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/40",
+    "status": "completed",
+    "topic": {
+      "title": "Topic 40",
+      "description": "Description 40",
+      "remark": "Remark 40",
+      "suggestBy": {
+        "fullName": "Alice 340",
+        "email": "user340@example.com",
+        "username": "user340",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Alice 440",
+        "email": "user440@example.com",
+        "username": "user440",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Alice 240",
+        "email": "user240@example.com",
+        "username": "user240",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 41,
+    "meetingName": "Planning 41",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/41",
+    "status": "active",
+    "topic": {
+      "title": "Topic 41",
+      "description": "Description 41",
+      "remark": "Remark 41",
+      "suggestBy": {
+        "fullName": "Bob 341",
+        "email": "user341@example.com",
+        "username": "user341",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Bob 441",
+        "email": "user441@example.com",
+        "username": "user441",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 42,
+    "meetingName": "Review 42",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/42",
+    "status": "active",
+    "topic": {
+      "title": "Topic 42",
+      "description": "Description 42",
+      "remark": "Remark 42",
+      "suggestBy": {
+        "fullName": "Carol 342",
+        "email": "user342@example.com",
+        "username": "user342",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Carol 442",
+        "email": "user442@example.com",
+        "username": "user442",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 43,
+    "meetingName": "Sync 43",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/43",
+    "status": "active",
+    "topic": {
+      "title": "Topic 43",
+      "description": "Description 43",
+      "remark": "Remark 43",
+      "suggestBy": {
+        "fullName": "Dave 343",
+        "email": "user343@example.com",
+        "username": "user343",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Dave 443",
+        "email": "user443@example.com",
+        "username": "user443",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 44,
+    "meetingName": "Update 44",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/44",
+    "status": "active",
+    "topic": {
+      "title": "Topic 44",
+      "description": "Description 44",
+      "remark": "Remark 44",
+      "suggestBy": {
+        "fullName": "Eve 344",
+        "email": "user344@example.com",
+        "username": "user344",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Eve 444",
+        "email": "user444@example.com",
+        "username": "user444",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 45,
+    "meetingName": "Discussion 45",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/45",
+    "status": "active",
+    "topic": {
+      "title": "Topic 45",
+      "description": "Description 45",
+      "remark": "Remark 45",
+      "suggestBy": {
+        "fullName": "Frank 345",
+        "email": "user345@example.com",
+        "username": "user345",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Frank 445",
+        "email": "user445@example.com",
+        "username": "user445",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 46,
+    "meetingName": "Planning 46",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/46",
+    "status": "active",
+    "topic": {
+      "title": "Topic 46",
+      "description": "Description 46",
+      "remark": "Remark 46",
+      "suggestBy": {
+        "fullName": "Grace 346",
+        "email": "user346@example.com",
+        "username": "user346",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Grace 446",
+        "email": "user446@example.com",
+        "username": "user446",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 47,
+    "meetingName": "Review 47",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/47",
+    "status": "active",
+    "topic": {
+      "title": "Topic 47",
+      "description": "Description 47",
+      "remark": "Remark 47",
+      "suggestBy": {
+        "fullName": "Hank 347",
+        "email": "user347@example.com",
+        "username": "user347",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Hank 447",
+        "email": "user447@example.com",
+        "username": "user447",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 48,
+    "meetingName": "Sync 48",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/48",
+    "status": "active",
+    "topic": {
+      "title": "Topic 48",
+      "description": "Description 48",
+      "remark": "Remark 48",
+      "suggestBy": {
+        "fullName": "Ivy 348",
+        "email": "user348@example.com",
+        "username": "user348",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Ivy 448",
+        "email": "user448@example.com",
+        "username": "user448",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 49,
+    "meetingName": "Update 49",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/49",
+    "status": "active",
+    "topic": {
+      "title": "Topic 49",
+      "description": "Description 49",
+      "remark": "Remark 49",
+      "suggestBy": {
+        "fullName": "Jack 349",
+        "email": "user349@example.com",
+        "username": "user349",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Jack 449",
+        "email": "user449@example.com",
+        "username": "user449",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 50,
+    "meetingName": "Discussion 50",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/50",
+    "status": "active",
+    "topic": {
+      "title": "Topic 50",
+      "description": "Description 50",
+      "remark": "Remark 50",
+      "suggestBy": {
+        "fullName": "Alice 350",
+        "email": "user350@example.com",
+        "username": "user350",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Alice 450",
+        "email": "user450@example.com",
+        "username": "user450",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 51,
+    "meetingName": "Planning 51",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/51",
+    "status": "active",
+    "topic": {
+      "title": "Topic 51",
+      "description": "Description 51",
+      "remark": "Remark 51",
+      "suggestBy": {
+        "fullName": "Bob 351",
+        "email": "user351@example.com",
+        "username": "user351",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Bob 451",
+        "email": "user451@example.com",
+        "username": "user451",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 52,
+    "meetingName": "Review 52",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/52",
+    "status": "active",
+    "topic": {
+      "title": "Topic 52",
+      "description": "Description 52",
+      "remark": "Remark 52",
+      "suggestBy": {
+        "fullName": "Carol 352",
+        "email": "user352@example.com",
+        "username": "user352",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Carol 452",
+        "email": "user452@example.com",
+        "username": "user452",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 53,
+    "meetingName": "Sync 53",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/53",
+    "status": "active",
+    "topic": {
+      "title": "Topic 53",
+      "description": "Description 53",
+      "remark": "Remark 53",
+      "suggestBy": {
+        "fullName": "Dave 353",
+        "email": "user353@example.com",
+        "username": "user353",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Dave 453",
+        "email": "user453@example.com",
+        "username": "user453",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 54,
+    "meetingName": "Update 54",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/54",
+    "status": "active",
+    "topic": {
+      "title": "Topic 54",
+      "description": "Description 54",
+      "remark": "Remark 54",
+      "suggestBy": {
+        "fullName": "Eve 354",
+        "email": "user354@example.com",
+        "username": "user354",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Eve 454",
+        "email": "user454@example.com",
+        "username": "user454",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 55,
+    "meetingName": "Discussion 55",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/55",
+    "status": "active",
+    "topic": {
+      "title": "Topic 55",
+      "description": "Description 55",
+      "remark": "Remark 55",
+      "suggestBy": {
+        "fullName": "Frank 355",
+        "email": "user355@example.com",
+        "username": "user355",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Frank 455",
+        "email": "user455@example.com",
+        "username": "user455",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 56,
+    "meetingName": "Planning 56",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/56",
+    "status": "active",
+    "topic": {
+      "title": "Topic 56",
+      "description": "Description 56",
+      "remark": "Remark 56",
+      "suggestBy": {
+        "fullName": "Grace 356",
+        "email": "user356@example.com",
+        "username": "user356",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Grace 456",
+        "email": "user456@example.com",
+        "username": "user456",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 57,
+    "meetingName": "Review 57",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/57",
+    "status": "active",
+    "topic": {
+      "title": "Topic 57",
+      "description": "Description 57",
+      "remark": "Remark 57",
+      "suggestBy": {
+        "fullName": "Hank 357",
+        "email": "user357@example.com",
+        "username": "user357",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Hank 457",
+        "email": "user457@example.com",
+        "username": "user457",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 58,
+    "meetingName": "Sync 58",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/58",
+    "status": "active",
+    "topic": {
+      "title": "Topic 58",
+      "description": "Description 58",
+      "remark": "Remark 58",
+      "suggestBy": {
+        "fullName": "Ivy 358",
+        "email": "user358@example.com",
+        "username": "user358",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Ivy 458",
+        "email": "user458@example.com",
+        "username": "user458",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 59,
+    "meetingName": "Update 59",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/59",
+    "status": "active",
+    "topic": {
+      "title": "Topic 59",
+      "description": "Description 59",
+      "remark": "Remark 59",
+      "suggestBy": {
+        "fullName": "Jack 359",
+        "email": "user359@example.com",
+        "username": "user359",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Jack 459",
+        "email": "user459@example.com",
+        "username": "user459",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 60,
+    "meetingName": "Discussion 60",
+    "scheduledDate": "2025-07-18",
+    "meetingLink": "https://meeting.com/60",
+    "status": "active",
+    "topic": {
+      "title": "Topic 60",
+      "description": "Description 60",
+      "remark": "Remark 60",
+      "suggestBy": {
+        "fullName": "Alice 360",
+        "email": "user360@example.com",
+        "username": "user360",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Alice 460",
+        "email": "user460@example.com",
+        "username": "user460",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": null
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 61,
+    "meetingName": "Planning 61",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/61",
+    "status": "active",
+    "topic": {
+      "title": "Topic 61",
+      "description": "Description 61",
+      "remark": "Remark 61",
+      "suggestBy": {
+        "fullName": "Bob 361",
+        "email": "user361@example.com",
+        "username": "user361",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Bob 461",
+        "email": "user461@example.com",
+        "username": "user461",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Bob 261",
+        "email": "user261@example.com",
+        "username": "user261",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 62,
+    "meetingName": "Review 62",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/62",
+    "status": "active",
+    "topic": {
+      "title": "Topic 62",
+      "description": "Description 62",
+      "remark": "Remark 62",
+      "suggestBy": {
+        "fullName": "Carol 362",
+        "email": "user362@example.com",
+        "username": "user362",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Carol 462",
+        "email": "user462@example.com",
+        "username": "user462",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Carol 262",
+        "email": "user262@example.com",
+        "username": "user262",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 63,
+    "meetingName": "Sync 63",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/63",
+    "status": "active",
+    "topic": {
+      "title": "Topic 63",
+      "description": "Description 63",
+      "remark": "Remark 63",
+      "suggestBy": {
+        "fullName": "Dave 363",
+        "email": "user363@example.com",
+        "username": "user363",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Dave 463",
+        "email": "user463@example.com",
+        "username": "user463",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Dave 263",
+        "email": "user263@example.com",
+        "username": "user263",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 64,
+    "meetingName": "Update 64",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/64",
+    "status": "active",
+    "topic": {
+      "title": "Topic 64",
+      "description": "Description 64",
+      "remark": "Remark 64",
+      "suggestBy": {
+        "fullName": "Eve 364",
+        "email": "user364@example.com",
+        "username": "user364",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Eve 464",
+        "email": "user464@example.com",
+        "username": "user464",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Eve 264",
+        "email": "user264@example.com",
+        "username": "user264",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 65,
+    "meetingName": "Discussion 65",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/65",
+    "status": "active",
+    "topic": {
+      "title": "Topic 65",
+      "description": "Description 65",
+      "remark": "Remark 65",
+      "suggestBy": {
+        "fullName": "Frank 365",
+        "email": "user365@example.com",
+        "username": "user365",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Frank 465",
+        "email": "user465@example.com",
+        "username": "user465",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Frank 265",
+        "email": "user265@example.com",
+        "username": "user265",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 66,
+    "meetingName": "Planning 66",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/66",
+    "status": "active",
+    "topic": {
+      "title": "Topic 66",
+      "description": "Description 66",
+      "remark": "Remark 66",
+      "suggestBy": {
+        "fullName": "Grace 366",
+        "email": "user366@example.com",
+        "username": "user366",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Grace 466",
+        "email": "user466@example.com",
+        "username": "user466",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Grace 266",
+        "email": "user266@example.com",
+        "username": "user266",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 67,
+    "meetingName": "Review 67",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/67",
+    "status": "active",
+    "topic": {
+      "title": "Topic 67",
+      "description": "Description 67",
+      "remark": "Remark 67",
+      "suggestBy": {
+        "fullName": "Hank 367",
+        "email": "user367@example.com",
+        "username": "user367",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Hank 467",
+        "email": "user467@example.com",
+        "username": "user467",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Hank 267",
+        "email": "user267@example.com",
+        "username": "user267",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 68,
+    "meetingName": "Sync 68",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/68",
+    "status": "active",
+    "topic": {
+      "title": "Topic 68",
+      "description": "Description 68",
+      "remark": "Remark 68",
+      "suggestBy": {
+        "fullName": "Ivy 368",
+        "email": "user368@example.com",
+        "username": "user368",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Ivy 468",
+        "email": "user468@example.com",
+        "username": "user468",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Ivy 268",
+        "email": "user268@example.com",
+        "username": "user268",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 69,
+    "meetingName": "Update 69",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/69",
+    "status": "active",
+    "topic": {
+      "title": "Topic 69",
+      "description": "Description 69",
+      "remark": "Remark 69",
+      "suggestBy": {
+        "fullName": "Jack 369",
+        "email": "user369@example.com",
+        "username": "user369",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Jack 469",
+        "email": "user469@example.com",
+        "username": "user469",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Jack 269",
+        "email": "user269@example.com",
+        "username": "user269",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 70,
+    "meetingName": "Discussion 70",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/70",
+    "status": "active",
+    "topic": {
+      "title": "Topic 70",
+      "description": "Description 70",
+      "remark": "Remark 70",
+      "suggestBy": {
+        "fullName": "Alice 370",
+        "email": "user370@example.com",
+        "username": "user370",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Alice 470",
+        "email": "user470@example.com",
+        "username": "user470",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Alice 270",
+        "email": "user270@example.com",
+        "username": "user270",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 71,
+    "meetingName": "Planning 71",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/71",
+    "status": "active",
+    "topic": {
+      "title": "Topic 71",
+      "description": "Description 71",
+      "remark": "Remark 71",
+      "suggestBy": {
+        "fullName": "Bob 371",
+        "email": "user371@example.com",
+        "username": "user371",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Bob 471",
+        "email": "user471@example.com",
+        "username": "user471",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Bob 271",
+        "email": "user271@example.com",
+        "username": "user271",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 72,
+    "meetingName": "Review 72",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/72",
+    "status": "active",
+    "topic": {
+      "title": "Topic 72",
+      "description": "Description 72",
+      "remark": "Remark 72",
+      "suggestBy": {
+        "fullName": "Carol 372",
+        "email": "user372@example.com",
+        "username": "user372",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Carol 472",
+        "email": "user472@example.com",
+        "username": "user472",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Carol 272",
+        "email": "user272@example.com",
+        "username": "user272",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 73,
+    "meetingName": "Sync 73",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/73",
+    "status": "active",
+    "topic": {
+      "title": "Topic 73",
+      "description": "Description 73",
+      "remark": "Remark 73",
+      "suggestBy": {
+        "fullName": "Dave 373",
+        "email": "user373@example.com",
+        "username": "user373",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Dave 473",
+        "email": "user473@example.com",
+        "username": "user473",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Dave 273",
+        "email": "user273@example.com",
+        "username": "user273",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 74,
+    "meetingName": "Update 74",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/74",
+    "status": "active",
+    "topic": {
+      "title": "Topic 74",
+      "description": "Description 74",
+      "remark": "Remark 74",
+      "suggestBy": {
+        "fullName": "Eve 374",
+        "email": "user374@example.com",
+        "username": "user374",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Eve 474",
+        "email": "user474@example.com",
+        "username": "user474",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Eve 274",
+        "email": "user274@example.com",
+        "username": "user274",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 75,
+    "meetingName": "Discussion 75",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/75",
+    "status": "active",
+    "topic": {
+      "title": "Topic 75",
+      "description": "Description 75",
+      "remark": "Remark 75",
+      "suggestBy": {
+        "fullName": "Frank 375",
+        "email": "user375@example.com",
+        "username": "user375",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Frank 475",
+        "email": "user475@example.com",
+        "username": "user475",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Frank 275",
+        "email": "user275@example.com",
+        "username": "user275",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 76,
+    "meetingName": "Planning 76",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/76",
+    "status": "active",
+    "topic": {
+      "title": "Topic 76",
+      "description": "Description 76",
+      "remark": "Remark 76",
+      "suggestBy": {
+        "fullName": "Grace 376",
+        "email": "user376@example.com",
+        "username": "user376",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Grace 476",
+        "email": "user476@example.com",
+        "username": "user476",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Grace 276",
+        "email": "user276@example.com",
+        "username": "user276",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 77,
+    "meetingName": "Review 77",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/77",
+    "status": "active",
+    "topic": {
+      "title": "Topic 77",
+      "description": "Description 77",
+      "remark": "Remark 77",
+      "suggestBy": {
+        "fullName": "Hank 377",
+        "email": "user377@example.com",
+        "username": "user377",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Hank 477",
+        "email": "user477@example.com",
+        "username": "user477",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Hank 277",
+        "email": "user277@example.com",
+        "username": "user277",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 78,
+    "meetingName": "Sync 78",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/78",
+    "status": "active",
+    "topic": {
+      "title": "Topic 78",
+      "description": "Description 78",
+      "remark": "Remark 78",
+      "suggestBy": {
+        "fullName": "Ivy 378",
+        "email": "user378@example.com",
+        "username": "user378",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Ivy 478",
+        "email": "user478@example.com",
+        "username": "user478",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Ivy 278",
+        "email": "user278@example.com",
+        "username": "user278",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 79,
+    "meetingName": "Update 79",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/79",
+    "status": "active",
+    "topic": {
+      "title": "Topic 79",
+      "description": "Description 79",
+      "remark": "Remark 79",
+      "suggestBy": {
+        "fullName": "Jack 379",
+        "email": "user379@example.com",
+        "username": "user379",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Jack 479",
+        "email": "user479@example.com",
+        "username": "user479",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Jack 279",
+        "email": "user279@example.com",
+        "username": "user279",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 80,
+    "meetingName": "Discussion 80",
+    "scheduledDate": "2025-07-28",
+    "meetingLink": "https://meeting.com/80",
+    "status": "active",
+    "topic": {
+      "title": "Topic 80",
+      "description": "Description 80",
+      "remark": "Remark 80",
+      "suggestBy": {
+        "fullName": "Alice 380",
+        "email": "user380@example.com",
+        "username": "user380",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Alice 480",
+        "email": "user480@example.com",
+        "username": "user480",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Alice 280",
+        "email": "user280@example.com",
+        "username": "user280",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 81,
+    "meetingName": "Planning 81",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/81",
+    "status": "active",
+    "topic": {
+      "title": "Topic 81",
+      "description": "Description 81",
+      "remark": "Remark 81",
+      "suggestBy": {
+        "fullName": "Bob 381",
+        "email": "user381@example.com",
+        "username": "user381",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Bob 481",
+        "email": "user481@example.com",
+        "username": "user481",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Bob 281",
+        "email": "user281@example.com",
+        "username": "user281",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 82,
+    "meetingName": "Review 82",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/82",
+    "status": "active",
+    "topic": {
+      "title": "Topic 82",
+      "description": "Description 82",
+      "remark": "Remark 82",
+      "suggestBy": {
+        "fullName": "Carol 382",
+        "email": "user382@example.com",
+        "username": "user382",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Carol 482",
+        "email": "user482@example.com",
+        "username": "user482",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Carol 282",
+        "email": "user282@example.com",
+        "username": "user282",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 83,
+    "meetingName": "Sync 83",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/83",
+    "status": "active",
+    "topic": {
+      "title": "Topic 83",
+      "description": "Description 83",
+      "remark": "Remark 83",
+      "suggestBy": {
+        "fullName": "Dave 383",
+        "email": "user383@example.com",
+        "username": "user383",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Dave 483",
+        "email": "user483@example.com",
+        "username": "user483",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Dave 283",
+        "email": "user283@example.com",
+        "username": "user283",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 84,
+    "meetingName": "Update 84",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/84",
+    "status": "active",
+    "topic": {
+      "title": "Topic 84",
+      "description": "Description 84",
+      "remark": "Remark 84",
+      "suggestBy": {
+        "fullName": "Eve 384",
+        "email": "user384@example.com",
+        "username": "user384",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Eve 484",
+        "email": "user484@example.com",
+        "username": "user484",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Eve 284",
+        "email": "user284@example.com",
+        "username": "user284",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 85,
+    "meetingName": "Discussion 85",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/85",
+    "status": "active",
+    "topic": {
+      "title": "Topic 85",
+      "description": "Description 85",
+      "remark": "Remark 85",
+      "suggestBy": {
+        "fullName": "Frank 385",
+        "email": "user385@example.com",
+        "username": "user385",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Frank 485",
+        "email": "user485@example.com",
+        "username": "user485",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Frank 285",
+        "email": "user285@example.com",
+        "username": "user285",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 86,
+    "meetingName": "Planning 86",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/86",
+    "status": "active",
+    "topic": {
+      "title": "Topic 86",
+      "description": "Description 86",
+      "remark": "Remark 86",
+      "suggestBy": {
+        "fullName": "Grace 386",
+        "email": "user386@example.com",
+        "username": "user386",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Grace 486",
+        "email": "user486@example.com",
+        "username": "user486",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Grace 286",
+        "email": "user286@example.com",
+        "username": "user286",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 87,
+    "meetingName": "Review 87",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/87",
+    "status": "active",
+    "topic": {
+      "title": "Topic 87",
+      "description": "Description 87",
+      "remark": "Remark 87",
+      "suggestBy": {
+        "fullName": "Hank 387",
+        "email": "user387@example.com",
+        "username": "user387",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Hank 487",
+        "email": "user487@example.com",
+        "username": "user487",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Hank 287",
+        "email": "user287@example.com",
+        "username": "user287",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 88,
+    "meetingName": "Sync 88",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/88",
+    "status": "active",
+    "topic": {
+      "title": "Topic 88",
+      "description": "Description 88",
+      "remark": "Remark 88",
+      "suggestBy": {
+        "fullName": "Ivy 388",
+        "email": "user388@example.com",
+        "username": "user388",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Ivy 488",
+        "email": "user488@example.com",
+        "username": "user488",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Ivy 288",
+        "email": "user288@example.com",
+        "username": "user288",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 89,
+    "meetingName": "Update 89",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/89",
+    "status": "active",
+    "topic": {
+      "title": "Topic 89",
+      "description": "Description 89",
+      "remark": "Remark 89",
+      "suggestBy": {
+        "fullName": "Jack 389",
+        "email": "user389@example.com",
+        "username": "user389",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Jack 489",
+        "email": "user489@example.com",
+        "username": "user489",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Jack 289",
+        "email": "user289@example.com",
+        "username": "user289",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 90,
+    "meetingName": "Discussion 90",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/90",
+    "status": "active",
+    "topic": {
+      "title": "Topic 90",
+      "description": "Description 90",
+      "remark": "Remark 90",
+      "suggestBy": {
+        "fullName": "Alice 390",
+        "email": "user390@example.com",
+        "username": "user390",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Alice 490",
+        "email": "user490@example.com",
+        "username": "user490",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Alice 290",
+        "email": "user290@example.com",
+        "username": "user290",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 91,
+    "meetingName": "Planning 91",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/91",
+    "status": "active",
+    "topic": {
+      "title": "Topic 91",
+      "description": "Description 91",
+      "remark": "Remark 91",
+      "suggestBy": {
+        "fullName": "Bob 391",
+        "email": "user391@example.com",
+        "username": "user391",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Bob 491",
+        "email": "user491@example.com",
+        "username": "user491",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Bob 291",
+        "email": "user291@example.com",
+        "username": "user291",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 92,
+    "meetingName": "Review 92",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/92",
+    "status": "active",
+    "topic": {
+      "title": "Topic 92",
+      "description": "Description 92",
+      "remark": "Remark 92",
+      "suggestBy": {
+        "fullName": "Carol 392",
+        "email": "user392@example.com",
+        "username": "user392",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Carol 492",
+        "email": "user492@example.com",
+        "username": "user492",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Carol 292",
+        "email": "user292@example.com",
+        "username": "user292",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 93,
+    "meetingName": "Sync 93",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/93",
+    "status": "active",
+    "topic": {
+      "title": "Topic 93",
+      "description": "Description 93",
+      "remark": "Remark 93",
+      "suggestBy": {
+        "fullName": "Dave 393",
+        "email": "user393@example.com",
+        "username": "user393",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Dave 493",
+        "email": "user493@example.com",
+        "username": "user493",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Dave 293",
+        "email": "user293@example.com",
+        "username": "user293",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 94,
+    "meetingName": "Update 94",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/94",
+    "status": "active",
+    "topic": {
+      "title": "Topic 94",
+      "description": "Description 94",
+      "remark": "Remark 94",
+      "suggestBy": {
+        "fullName": "Eve 394",
+        "email": "user394@example.com",
+        "username": "user394",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Eve 494",
+        "email": "user494@example.com",
+        "username": "user494",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Eve 294",
+        "email": "user294@example.com",
+        "username": "user294",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 95,
+    "meetingName": "Discussion 95",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/95",
+    "status": "active",
+    "topic": {
+      "title": "Topic 95",
+      "description": "Description 95",
+      "remark": "Remark 95",
+      "suggestBy": {
+        "fullName": "Frank 395",
+        "email": "user395@example.com",
+        "username": "user395",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Frank 495",
+        "email": "user495@example.com",
+        "username": "user495",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Frank 295",
+        "email": "user295@example.com",
+        "username": "user295",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 96,
+    "meetingName": "Planning 96",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/96",
+    "status": "active",
+    "topic": {
+      "title": "Topic 96",
+      "description": "Description 96",
+      "remark": "Remark 96",
+      "suggestBy": {
+        "fullName": "Grace 396",
+        "email": "user396@example.com",
+        "username": "user396",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Grace 496",
+        "email": "user496@example.com",
+        "username": "user496",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Grace 296",
+        "email": "user296@example.com",
+        "username": "user296",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  },
+  {
+    "id": 97,
+    "meetingName": "Review 97",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/97",
+    "status": "active",
+    "topic": {
+      "title": "Topic 97",
+      "description": "Description 97",
+      "remark": "Remark 97",
+      "suggestBy": {
+        "fullName": "Hank 397",
+        "email": "user397@example.com",
+        "username": "user397",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Hank 497",
+        "email": "user497@example.com",
+        "username": "user497",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      },
+      "host": {
+        "fullName": "Hank 297",
+        "email": "user297@example.com",
+        "username": "user297",
+        "companyBranch": {
+          "name": "Branch B"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch B"
+    }
+  },
+  {
+    "id": 98,
+    "meetingName": "Sync 98",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/98",
+    "status": "active",
+    "topic": {
+      "title": "Topic 98",
+      "description": "Description 98",
+      "remark": "Remark 98",
+      "suggestBy": {
+        "fullName": "Ivy 398",
+        "email": "user398@example.com",
+        "username": "user398",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Ivy 498",
+        "email": "user498@example.com",
+        "username": "user498",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      },
+      "host": {
+        "fullName": "Ivy 298",
+        "email": "user298@example.com",
+        "username": "user298",
+        "companyBranch": {
+          "name": "Branch C"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch C"
+    }
+  },
+  {
+    "id": 99,
+    "meetingName": "Update 99",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/99",
+    "status": "active",
+    "topic": {
+      "title": "Topic 99",
+      "description": "Description 99",
+      "remark": "Remark 99",
+      "suggestBy": {
+        "fullName": "Jack 399",
+        "email": "user399@example.com",
+        "username": "user399",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Jack 499",
+        "email": "user499@example.com",
+        "username": "user499",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      },
+      "host": {
+        "fullName": "Jack 299",
+        "email": "user299@example.com",
+        "username": "user299",
+        "companyBranch": {
+          "name": "Branch D"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch D"
+    }
+  },
+  {
+    "id": 100,
+    "meetingName": "Discussion 100",
+    "scheduledDate": "2025-07-13",
+    "meetingLink": "https://meeting.com/100",
+    "status": "active",
+    "topic": {
+      "title": "Topic 100",
+      "description": "Description 100",
+      "remark": "Remark 100",
+      "suggestBy": {
+        "fullName": "Alice 400",
+        "email": "user400@example.com",
+        "username": "user400",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "evaluteBy": {
+        "fullName": "Alice 500",
+        "email": "user500@example.com",
+        "username": "user500",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      },
+      "host": {
+        "fullName": "Alice 300",
+        "email": "user300@example.com",
+        "username": "user300",
+        "companyBranch": {
+          "name": "Branch A"
+        }
+      }
+    },
+    "companyBranch": {
+      "name": "Branch A"
+    }
+  }
+];
+export default meetingMockData;

--- a/OpenTalk_FE/src/pages/MeetingDetailPage.jsx
+++ b/OpenTalk_FE/src/pages/MeetingDetailPage.jsx
@@ -1,108 +1,150 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { FaArrowLeft } from 'react-icons/fa';
+import { FaArrowLeft, FaEnvelope, FaPhone } from 'react-icons/fa';
 import { getMeetingById } from '../api/meeting';
+import { meetingMockData } from '../mock/MeetingMockData';
 import './styles/MeetingDetailPage.css';
 
-const mockMeetings = [
-  { id: 1, topicName: 'Weekly Sync', scheduledDate: '2025-07-14 10:00', meetingLink: 'https://meeting.com/1', branchName: 'Unpixel HQ' },
-  { id: 2, topicName: 'Project Kickoff', scheduledDate: '2025-07-15 09:00', meetingLink: 'https://meeting.com/2', branchName: 'North Branch' },
-  { id: 3, topicName: 'Design Review', scheduledDate: '2025-07-16 13:00', meetingLink: 'https://meeting.com/3', branchName: 'South Branch' },
-  { id: 4, topicName: 'Sprint Planning', scheduledDate: '2025-07-17 11:00', meetingLink: 'https://meeting.com/4', branchName: 'East Branch' },
-  { id: 5, topicName: 'Retrospective', scheduledDate: '2025-07-18 16:00', meetingLink: 'https://meeting.com/5', branchName: 'Unpixel HQ' },
-  { id: 6, topicName: 'Client Demo', scheduledDate: '2025-07-19 15:00', meetingLink: 'https://meeting.com/6', branchName: 'North Branch' },
-  { id: 7, topicName: 'Team Building', scheduledDate: '2025-07-20 10:30', meetingLink: 'https://meeting.com/7', branchName: 'South Branch' },
-  { id: 8, topicName: 'Marketing Update', scheduledDate: '2025-07-21 12:00', meetingLink: 'https://meeting.com/8', branchName: 'East Branch' },
-  { id: 9, topicName: 'Budget Review', scheduledDate: '2025-07-22 09:30', meetingLink: 'https://meeting.com/9', branchName: 'Unpixel HQ' },
-  { id: 10, topicName: 'One-on-One', scheduledDate: '2025-07-23 14:00', meetingLink: 'https://meeting.com/10', branchName: 'North Branch' },
-  { id: 11, topicName: 'All Hands', scheduledDate: '2025-07-24 11:30', meetingLink: 'https://meeting.com/11', branchName: 'South Branch' },
-  { id: 12, topicName: 'Tech Sync', scheduledDate: '2025-07-25 09:45', meetingLink: 'https://meeting.com/12', branchName: 'East Branch' },
-  { id: 13, topicName: 'Roadmap Planning', scheduledDate: '2025-07-26 15:30', meetingLink: 'https://meeting.com/13', branchName: 'Unpixel HQ' },
-  { id: 14, topicName: 'Hiring Discussion', scheduledDate: '2025-07-27 16:15', meetingLink: 'https://meeting.com/14', branchName: 'North Branch' },
-  { id: 15, topicName: 'Customer Feedback', scheduledDate: '2025-07-28 10:45', meetingLink: 'https://meeting.com/15', branchName: 'South Branch' },
-  { id: 16, topicName: 'Training Session', scheduledDate: '2025-07-29 13:15', meetingLink: 'https://meeting.com/16', branchName: 'East Branch' },
-  { id: 17, topicName: 'Product Launch', scheduledDate: '2025-07-30 09:00', meetingLink: 'https://meeting.com/17', branchName: 'Unpixel HQ' },
-  { id: 18, topicName: 'Partnership Call', scheduledDate: '2025-07-31 14:30', meetingLink: 'https://meeting.com/18', branchName: 'North Branch' },
-  { id: 19, topicName: 'UX Brainstorm', scheduledDate: '2025-08-01 11:00', meetingLink: 'https://meeting.com/19', branchName: 'South Branch' },
-  { id: 20, topicName: 'Quarterly Review', scheduledDate: '2025-08-02 16:45', meetingLink: 'https://meeting.com/20', branchName: 'East Branch' }
-];
-
-const mockMeeting = {
-  id: 0,
-  topicName: '',
-  scheduledDate: '',
-  meetingLink: '',
-  branchName: '',
-  status: ''
-};
-
 const MeetingDetailPage = () => {
-  const { id } = useParams();
-  const navigate = useNavigate();
-  const [meeting, setMeeting] = useState(null);
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [meeting, setMeeting] = useState(null);
+    const [activeTab, setActiveTab] = useState('general');
 
-  useEffect(() => {
-    // show mock data immediately
-    const local = mockMeetings.find((m) => m.id === Number(id));
-    setMeeting(local || mockMeeting);
+    useEffect(() => {
+        const local = meetingMockData.find((m) => m.id === Number(id));
+        setMeeting(local);
+        const load = async () => {
+            try {
+                const data = await getMeetingById(id);
+                setMeeting(data);
+            } catch (e) {
+                console.error(e);
+            }
+        };
+        load();
+    }, [id]);
 
-    const loadData = async () => {
-      try {
-        const data = await getMeetingById(id);
-        setMeeting(data);
-      } catch (e) {
-        console.error(e);
-        // keep the mock data if the API call fails
-      }
-    };
+    if (!meeting) return <div className="meeting-detail-page" />;
 
-    loadData();
-  }, [id]);
+    const host = meeting.topic.host;
+    const suggestBy = meeting.topic.suggestBy;
+    const evaluteBy = meeting.topic.evaluteBy;
 
-  if (!meeting) return <div className="meeting-detail-page" />;
+    const renderUserInfo = (user) => (
+        <>
+            <div className="profile-header">
+                <img
+                    src="/placeholder.svg"
+                    alt={user.fullName}
+                    className="profile-avatar"
+                />
+                <h2 className="profile-name">{user.fullName}</h2>
+                <p className="profile-title">{user.username}</p>
+            </div>
+            <div className="contact-info">
+                <div className="contact-item">
+                    <FaEnvelope className="contact-icon" />
+                    <span>{user.email}</span>
+                </div>
+                <div className="contact-item">
+                    <FaPhone className="contact-icon" />
+                    <span>000-000-0000</span>
+                </div>
+                <div className="contact-item">
+                    <span>Branch: {user.companyBranch.name}</span>
+                </div>
+            </div>
+        </>
+    );
 
-  return (
-    <div className="meeting-detail-page">
-      <div className="page-header">
-        <button onClick={() => navigate('/meeting')} className="back-button">
-          <FaArrowLeft size={16} />
-        </button>
-        <h1 className="page-title">{meeting.topicName || meeting.meetingName}</h1>
-      </div>
+    return (
+        <div className="meeting-detail-page">
+            <div className="page-header">
+                <button onClick={() => navigate('/meeting')} className="back-button">
+                    <FaArrowLeft size={16} />
+                </button>
+                <h1 className="page-title">{meeting.meetingName}</h1>
+            </div>
 
-      <div className="detail-card">
-        <div className="detail-row">
-          <span className="label">Scheduled Date:</span>
-          <span className="value">{meeting.scheduledDate}</span>
+            <div className="content-grid">
+                <div className="profile-card">
+                    {host ? renderUserInfo(host) : (
+                        <div className="profile-header">
+                            <img src="/placeholder.svg" alt="No Host" className="profile-avatar" />
+                            <h2 className="profile-name">No Host</h2>
+                        </div>
+                    )}
+                </div>
+
+                <div className="main-content">
+                    <div className="tabs-header">
+                        <button
+                            className={`tab-button ${activeTab === 'general' ? 'active' : ''}`}
+                            onClick={() => setActiveTab('general')}
+                        >
+                            Meeting General
+                        </button>
+                        <button
+                            className={`tab-button ${activeTab === 'suggest' ? 'active' : ''}`}
+                            onClick={() => setActiveTab('suggest')}
+                        >
+                            Suggested By
+                        </button>
+                        <button
+                            className={`tab-button ${activeTab === 'evaluate' ? 'active' : ''}`}
+                            onClick={() => setActiveTab('evaluate')}
+                        >
+                            Evaluated By
+                        </button>
+                    </div>
+
+                    <div className="tab-content">
+                        {activeTab === 'general' && (
+                            <>
+                                <div className="detail-row">
+                                    <span className="label">Meeting Name:</span>
+                                    <span className="value">{meeting.meetingName}</span>
+                                </div>
+                                <div className="detail-row">
+                                    <span className="label">Scheduled Date:</span>
+                                    <span className="value">{meeting.scheduledDate}</span>
+                                </div>
+                                <div className="detail-row">
+                                    <span className="label">Meeting Link:</span>
+                                    <a href={meeting.meetingLink} className="value link" target="_blank" rel="noreferrer">
+                                        {meeting.meetingLink}
+                                    </a>
+                                </div>
+                                <div className="detail-row">
+                                    <span className="label">Status:</span>
+                                    <span className="value">{meeting.status}</span>
+                                </div>
+                                <div className="detail-row">
+                                    <span className="label">Topic Title:</span>
+                                    <span className="value">{meeting.topic.title}</span>
+                                </div>
+                                <div className="detail-row">
+                                    <span className="label">Description:</span>
+                                    <span className="value">{meeting.topic.description}</span>
+                                </div>
+                                <div className="detail-row">
+                                    <span className="label">Remark:</span>
+                                    <span className="value">{meeting.topic.remark}</span>
+                                </div>
+                                <div className="detail-row">
+                                    <span className="label">Branch:</span>
+                                    <span className="value">{meeting.companyBranch.name}</span>
+                                </div>
+                            </>
+                        )}
+                        {activeTab === 'suggest' && suggestBy && renderUserInfo(suggestBy)}
+                        {activeTab === 'evaluate' && evaluteBy && renderUserInfo(evaluteBy)}
+                    </div>
+                </div>
+            </div>
         </div>
-        {meeting.branchName && (
-          <div className="detail-row">
-            <span className="label">Branch:</span>
-            <span className="value">{meeting.branchName}</span>
-          </div>
-        )}
-        {meeting.meetingLink && (
-          <div className="detail-row">
-            <span className="label">Meeting Link:</span>
-            <a
-              href={meeting.meetingLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="value link"
-            >
-              {meeting.meetingLink}
-            </a>
-          </div>
-        )}
-        {meeting.status !== undefined && (
-          <div className="detail-row">
-            <span className="label">Status:</span>
-            <span className="value">{meeting.status || (meeting.isEnabled ? 'Enabled' : 'Disabled')}</span>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+    );
 };
 
 export default MeetingDetailPage;

--- a/OpenTalk_FE/src/pages/MeetingListPage.jsx
+++ b/OpenTalk_FE/src/pages/MeetingListPage.jsx
@@ -4,55 +4,43 @@ import MeetingCard from '../components/meetingCard/MeetingCard';
 import { FaSearch, FaChevronDown, FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 import { getMeetings } from '../api/meeting';
 import { getCompanyBranches } from '../api/companyBranch';
+import { OpenTalkMeetingStatus } from '../constants/enums/openTalkMeetingStatus';
+import { meetingMockData } from '../mock/MeetingMockData';
 import './styles/MeetingListPage.css';
 
-const mockMeetings = [
-  { id: 1, topicName: 'Weekly Sync', scheduledDate: '2025-07-14 10:00', meetingLink: 'https://meeting.com/1', branchName: 'Unpixel HQ' },
-  { id: 2, topicName: 'Project Kickoff', scheduledDate: '2025-07-15 09:00', meetingLink: 'https://meeting.com/2', branchName: 'North Branch' },
-  { id: 3, topicName: 'Design Review', scheduledDate: '2025-07-16 13:00', meetingLink: 'https://meeting.com/3', branchName: 'South Branch' },
-  { id: 4, topicName: 'Sprint Planning', scheduledDate: '2025-07-17 11:00', meetingLink: 'https://meeting.com/4', branchName: 'East Branch' },
-  { id: 5, topicName: 'Retrospective', scheduledDate: '2025-07-18 16:00', meetingLink: 'https://meeting.com/5', branchName: 'Unpixel HQ' },
-  { id: 6, topicName: 'Client Demo', scheduledDate: '2025-07-19 15:00', meetingLink: 'https://meeting.com/6', branchName: 'North Branch' },
-  { id: 7, topicName: 'Team Building', scheduledDate: '2025-07-20 10:30', meetingLink: 'https://meeting.com/7', branchName: 'South Branch' },
-  { id: 8, topicName: 'Marketing Update', scheduledDate: '2025-07-21 12:00', meetingLink: 'https://meeting.com/8', branchName: 'East Branch' },
-  { id: 9, topicName: 'Budget Review', scheduledDate: '2025-07-22 09:30', meetingLink: 'https://meeting.com/9', branchName: 'Unpixel HQ' },
-  { id: 10, topicName: 'One-on-One', scheduledDate: '2025-07-23 14:00', meetingLink: 'https://meeting.com/10', branchName: 'North Branch' },
-  { id: 11, topicName: 'All Hands', scheduledDate: '2025-07-24 11:30', meetingLink: 'https://meeting.com/11', branchName: 'South Branch' },
-  { id: 12, topicName: 'Tech Sync', scheduledDate: '2025-07-25 09:45', meetingLink: 'https://meeting.com/12', branchName: 'East Branch' },
-  { id: 13, topicName: 'Roadmap Planning', scheduledDate: '2025-07-26 15:30', meetingLink: 'https://meeting.com/13', branchName: 'Unpixel HQ' },
-  { id: 14, topicName: 'Hiring Discussion', scheduledDate: '2025-07-27 16:15', meetingLink: 'https://meeting.com/14', branchName: 'North Branch' },
-  { id: 15, topicName: 'Customer Feedback', scheduledDate: '2025-07-28 10:45', meetingLink: 'https://meeting.com/15', branchName: 'South Branch' },
-  { id: 16, topicName: 'Training Session', scheduledDate: '2025-07-29 13:15', meetingLink: 'https://meeting.com/16', branchName: 'East Branch' },
-  { id: 17, topicName: 'Product Launch', scheduledDate: '2025-07-30 09:00', meetingLink: 'https://meeting.com/17', branchName: 'Unpixel HQ' },
-  { id: 18, topicName: 'Partnership Call', scheduledDate: '2025-07-31 14:30', meetingLink: 'https://meeting.com/18', branchName: 'North Branch' },
-  { id: 19, topicName: 'UX Brainstorm', scheduledDate: '2025-08-01 11:00', meetingLink: 'https://meeting.com/19', branchName: 'South Branch' },
-  { id: 20, topicName: 'Quarterly Review', scheduledDate: '2025-08-02 16:45', meetingLink: 'https://meeting.com/20', branchName: 'East Branch' }
-];
-
 const mockBranches = [
-  { id: 1, name: 'Unpixel HQ' },
-  { id: 2, name: 'North Branch' },
-  { id: 3, name: 'South Branch' },
-  { id: 4, name: 'East Branch' },
+  { id: 1, name: 'Branch A' },
+  { id: 2, name: 'Branch B' },
+  { id: 3, name: 'Branch C' },
+  { id: 4, name: 'Branch D' },
 ];
 
 const MeetingListPage = () => {
   const navigate = useNavigate();
-  const [meetings, setMeetings] = useState(mockMeetings);
+  const [meetings, setMeetings] = useState(meetingMockData);
   const [branches, setBranches] = useState(mockBranches);
   const [searchTerm, setSearchTerm] = useState('');
   const [branchFilter, setBranchFilter] = useState('');
+  const [activeTab, setActiveTab] = useState('inactive');
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 8;
+
+  const tabs = [
+    { id: 'inactive', label: 'Inactive' },
+    { id: 'completed', label: 'Completed' },
+    { id: 'waitingHost', label: 'Waiting Host To Register' },
+    { id: 'notScheduled', label: 'Not Scheduled Yet' },
+    { id: 'ongoing', label: 'Ongoing' },
+  ];
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         const data = await getMeetings();
-        setMeetings(Array.isArray(data) ? data : mockMeetings);
+        setMeetings(Array.isArray(data) ? data : meetingMockData);
       } catch (e) {
         console.error(e);
-        setMeetings(mockMeetings);
+        setMeetings(meetingMockData);
       }
 
       try {
@@ -73,11 +61,48 @@ const MeetingListPage = () => {
     }
   };
 
-  const filteredMeetings = meetings.filter(
-    (m) =>
-      m.topicName.toLowerCase().includes(searchTerm.toLowerCase()) &&
-      (branchFilter ? m.branchName === branchFilter : true)
-  );
+  const now = new Date();
+
+  const filteredMeetings = meetings.filter((m) => {
+    const nameMatch = m.meetingName
+      .toLowerCase()
+      .includes(searchTerm.toLowerCase());
+    const branchMatch = branchFilter
+      ? m.companyBranch.name === branchFilter
+      : true;
+
+    if (!nameMatch || !branchMatch) return false;
+
+    const meetingDate = new Date(m.scheduledDate);
+    const diffDays = Math.floor((meetingDate - now) / (1000 * 60 * 60 * 24));
+
+    switch (activeTab) {
+      case 'inactive':
+        return m.status === OpenTalkMeetingStatus.INACTIVE;
+      case 'completed':
+        return m.status === OpenTalkMeetingStatus.COMPLETED;
+      case 'waitingHost':
+        return (
+          m.status === OpenTalkMeetingStatus.ACTIVE &&
+          !m.topic.host &&
+          diffDays <= 7 &&
+          diffDays > 0
+        );
+      case 'notScheduled':
+        return (
+          m.status === OpenTalkMeetingStatus.ACTIVE &&
+          diffDays > 0
+        );
+      case 'ongoing':
+        return (
+          m.status === OpenTalkMeetingStatus.ACTIVE &&
+          m.topic.host &&
+          meetingDate.toDateString() === now.toDateString()
+        );
+      default:
+        return true;
+    }
+  });
 
   const totalPages = Math.ceil(filteredMeetings.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
@@ -119,16 +144,43 @@ const MeetingListPage = () => {
         </div>
       </div>
 
+      <div className="tabs-header">
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => {
+              setActiveTab(t.id);
+              setCurrentPage(1);
+            }}
+            className={`tab-button ${activeTab === t.id ? 'active' : ''}`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
       <div className="meeting-list-container">
         {paginatedMeetings.map((m) => (
           <MeetingCard
             key={m.id}
-            title={m.topicName}
+            title={m.meetingName}
             time={m.scheduledDate}
             description={m.meetingLink}
             participants={[]}
             extraCount={0}
-            onJoin={() => handleJoin(m.meetingLink)}
+            showButton={
+              activeTab === 'waitingHost' || activeTab === 'ongoing'
+            }
+            actionLabel={
+              activeTab === 'waitingHost' ? 'Register Host' : 'Join Meeting'
+            }
+            onAction={() => {
+              if (activeTab === 'ongoing') {
+                handleJoin(m.meetingLink);
+              } else if (activeTab === 'waitingHost') {
+                navigate(`/meeting/${m.id}`);
+              }
+            }}
             onView={() => navigate(`/meeting/${m.id}`)}
           />
         ))}

--- a/OpenTalk_FE/src/pages/styles/MeetingDetailPage.css
+++ b/OpenTalk_FE/src/pages/styles/MeetingDetailPage.css
@@ -2,9 +2,7 @@
     padding: 24px;
     background-color: #f9fafb;
     min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 .page-header {
@@ -38,12 +36,102 @@
     margin: 0;
 }
 
-.detail-card {
+.content-grid {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: 24px;
+}
+
+.profile-card {
     background: white;
     border-radius: 12px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     padding: 24px;
-    max-width: 600px;
+    height: fit-content;
+}
+
+.profile-header {
+    text-align: center;
+    margin-bottom: 24px;
+}
+
+.profile-avatar {
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 16px;
+}
+
+.profile-name {
+    font-size: 20px;
+    font-weight: bold;
+    color: #111827;
+    margin: 0 0 4px 0;
+}
+
+.profile-title {
+    color: #6b7280;
+    margin: 0 0 12px 0;
+}
+
+.contact-info {
+    margin-bottom: 24px;
+}
+
+.contact-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+    color: #6b7280;
+    font-size: 14px;
+}
+
+.contact-icon {
+    width: 16px;
+    height: 16px;
+    color: #9ca3af;
+}
+
+.main-content {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+}
+
+.tabs-header {
+    display: flex;
+    border-bottom: 1px solid #e5e7eb;
+    background: #f9fafb;
+}
+
+.tab-button {
+    padding: 16px 24px;
+    border: none;
+    background: transparent;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+    border-bottom: 2px solid transparent;
+    color: #6b7280;
+}
+
+.tab-button.active {
+    color: #10b981;
+    border-bottom-color: #10b981;
+    background: white;
+}
+
+.tab-button:hover:not(.active) {
+    color: #374151;
+    background: #f3f4f6;
+}
+
+.tab-content {
+    padding: 32px;
 }
 
 .detail-row {
@@ -52,7 +140,7 @@
 }
 
 .label {
-    width: 140px;
+    width: 160px;
     font-weight: 500;
     color: #6b7280;
 }
@@ -65,3 +153,10 @@
     color: #0369a1;
     text-decoration: underline;
 }
+
+@media (max-width: 1024px) {
+    .content-grid {
+        grid-template-columns: 1fr;
+    }
+}
+

--- a/OpenTalk_FE/src/pages/styles/MeetingListPage.css
+++ b/OpenTalk_FE/src/pages/styles/MeetingListPage.css
@@ -139,3 +139,9 @@
 .pagination-number:not(.active):hover {
     background-color: #f9fafb;
 }
+
+.tabs-header { display: flex; border-bottom: 1px solid #e2e8f0; background-color: #f8fafc; margin-bottom: 20px; }
+.tab-button { padding: 12px 16px; border: none; background: transparent; cursor: pointer; font-size: 14px; font-weight: 500; color: #64748b; border-bottom: 3px solid transparent; transition: all 0.2s; }
+.tab-button.active { color: #10b981; border-bottom-color: #10b981; background-color: white; }
+.tab-button:hover:not(.active) { color: #334155; background-color: #f1f5f9; }
+


### PR DESCRIPTION
## Summary
- refactor MeetingCard to accept configurable action buttons
- integrate tabs and filtering logic in MeetingListPage
- overhaul MeetingDetailPage with profile layout and tabs
- add styles for new layouts
- create large mock dataset for meetings

## Testing
- `npm run lint` *(fails: cannot satisfy lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_6873749612e8832bac6ac118a8d5d777