### PR TITLE
Add download button in MeetingDetailPage header

### DIFF
--- a/OpenTalk_FE/src/pages/MeetingDetailPage.jsx
+++ b/OpenTalk_FE/src/pages/MeetingDetailPage.jsx
@@ -65,6 +65,7 @@ const MeetingDetailPage = () => {
                     <FaArrowLeft size={16} />
                 </button>
                 <h1 className="page-title">{meeting.meetingName}</h1>
+                <button className="download-button">Download material</button>
             </div>
 
             <div className="content-grid">

--- a/OpenTalk_FE/src/pages/styles/MeetingDetailPage.css
+++ b/OpenTalk_FE/src/pages/styles/MeetingDetailPage.css
@@ -11,6 +11,23 @@
     margin-bottom: 24px;
 }
 
+.download-button {
+    margin-left: auto;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 8px;
+    background-color: #10b981;
+    color: white;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.download-button:hover {
+    background-color: #059669;
+}
+
 .back-button {
     width: 40px;
     height: 40px;


### PR DESCRIPTION
## Summary
- add a new **Download material** button in the meeting details header
- style the download button to appear on the right side

## Testing
- `npm run lint` *(fails: 142 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68737bd73c24832b967a524527d02862