### PR TITLE
Enhance meeting pages with feedback section

### DIFF
--- a/OpenTalk_FE/src/api/__mocks__/data/feedback.js
+++ b/OpenTalk_FE/src/api/__mocks__/data/feedback.js
@@ -1,0 +1,14 @@
+export const feedbackMockData = {};
+
+for (let m = 1; m <= 100; m++) {
+    feedbackMockData[m] = Array.from({ length: 10 }).map((_, i) => ({
+        id: m * 10 + i,
+        meetingId: m,
+        user: {
+            username: `user${m}-${i + 1}`,
+            avatar: '/placeholder.svg',
+        },
+        rating: (i % 5) + 1,
+        comment: `This is feedback ${i + 1} for meeting ${m}`,
+    }));
+}

--- a/OpenTalk_FE/src/components/feedBackCard/FeedBackCard.css
+++ b/OpenTalk_FE/src/components/feedBackCard/FeedBackCard.css
@@ -1,0 +1,43 @@
+.feedback-card {
+    display: flex;
+    gap: 12px;
+    background: #fff;
+    padding: 12px 16px;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.feedback-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.feedback-info {
+    flex: 1;
+}
+
+.feedback-username {
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.feedback-rating {
+    display: flex;
+    gap: 2px;
+    margin-bottom: 4px;
+}
+
+.feedback-rating svg {
+    color: #d1d5db;
+}
+
+.feedback-rating .filled {
+    color: #f59e0b;
+}
+
+.feedback-comment {
+    font-size: 14px;
+    color: #374151;
+}

--- a/OpenTalk_FE/src/components/feedBackCard/FeedBackCard.jsx
+++ b/OpenTalk_FE/src/components/feedBackCard/FeedBackCard.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { FaStar } from 'react-icons/fa';
+import './FeedBackCard.css';
+
+const FeedBackCard = ({ feedback }) => {
+    const { user, rating, comment } = feedback;
+    return (
+        <div className="feedback-card">
+            <img
+                src={user.avatar || '/placeholder.svg'}
+                alt={user.username}
+                className="feedback-avatar"
+            />
+            <div className="feedback-info">
+                <div className="feedback-username">{user.username}</div>
+                <div className="feedback-rating">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                        <FaStar key={i} className={i < rating ? 'filled' : ''} />
+                    ))}
+                </div>
+                <div className="feedback-comment">{comment}</div>
+            </div>
+        </div>
+    );
+};
+
+export default FeedBackCard;

--- a/OpenTalk_FE/src/pages/MeetingDetailPage.jsx
+++ b/OpenTalk_FE/src/pages/MeetingDetailPage.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { FaArrowLeft, FaEnvelope, FaPhone } from 'react-icons/fa';
+import FeedBackCard from '../components/feedBackCard/FeedBackCard';
+import { feedbackMockData } from '../api/__mocks__/data/feedback';
 import { getMeetingById } from '../api/meeting';
 import { meetingMockData } from '../api/__mocks__/data/MeetingMockData';
 import './styles/MeetingDetailPage.css';
@@ -10,10 +12,12 @@ const MeetingDetailPage = () => {
     const navigate = useNavigate();
     const [meeting, setMeeting] = useState(null);
     const [activeTab, setActiveTab] = useState('general');
+    const [feedbacks, setFeedbacks] = useState([]);
 
     useEffect(() => {
         const local = meetingMockData.find((m) => m.id === Number(id));
         setMeeting(local);
+        setFeedbacks(feedbackMockData[id] || []);
         const load = async () => {
             try {
                 const data = await getMeetingById(id);
@@ -70,21 +74,46 @@ const MeetingDetailPage = () => {
 
             <div className="content-grid">
                 <div className="profile-card">
-                    {host ? renderUserInfo(host) : (
-                        <div className="profile-header">
-                            <img src="/placeholder.svg" alt="No Host" className="profile-avatar" />
-                            <h2 className="profile-name">No Host</h2>
+                    <div className="meeting-highlight">
+                        <h2 className="meeting-name">{meeting.meetingName}</h2>
+                        <div className="detail-row">
+                            <span className="label">Scheduled Date:</span>
+                            <span className="value">{meeting.scheduledDate}</span>
                         </div>
-                    )}
+                        <div className="detail-row">
+                            <span className="label">Meeting Link:</span>
+                            <a href={meeting.meetingLink} className="value link" target="_blank" rel="noreferrer">
+                                {meeting.meetingLink}
+                            </a>
+                        </div>
+                        <div className="detail-row">
+                            <span className="label">Status:</span>
+                            <span className="value">{meeting.status}</span>
+                        </div>
+                        <div className="detail-row">
+                            <span className="label">Branch:</span>
+                            <span className="value">{meeting.companyBranch.name}</span>
+                        </div>
+                    </div>
+                    <div className="host-section">
+                        <h3 className="section-title">Host</h3>
+                        {host ? renderUserInfo(host) : (
+                            <div className="profile-header">
+                                <img src="/placeholder.svg" alt="No Host" className="profile-avatar" />
+                                <h2 className="profile-name">No Host</h2>
+                            </div>
+                        )}
+                    </div>
                 </div>
 
-                <div className="main-content">
+                <div className="topic-content">
+                    <h2 className="section-title">Topic</h2>
                     <div className="tabs-header">
                         <button
                             className={`tab-button ${activeTab === 'general' ? 'active' : ''}`}
                             onClick={() => setActiveTab('general')}
                         >
-                            Meeting General
+                            Topic General
                         </button>
                         <button
                             className={`tab-button ${activeTab === 'suggest' ? 'active' : ''}`}
@@ -104,25 +133,7 @@ const MeetingDetailPage = () => {
                         {activeTab === 'general' && (
                             <>
                                 <div className="detail-row">
-                                    <span className="label">Meeting Name:</span>
-                                    <span className="value">{meeting.meetingName}</span>
-                                </div>
-                                <div className="detail-row">
-                                    <span className="label">Scheduled Date:</span>
-                                    <span className="value">{meeting.scheduledDate}</span>
-                                </div>
-                                <div className="detail-row">
-                                    <span className="label">Meeting Link:</span>
-                                    <a href={meeting.meetingLink} className="value link" target="_blank" rel="noreferrer">
-                                        {meeting.meetingLink}
-                                    </a>
-                                </div>
-                                <div className="detail-row">
-                                    <span className="label">Status:</span>
-                                    <span className="value">{meeting.status}</span>
-                                </div>
-                                <div className="detail-row">
-                                    <span className="label">Topic Title:</span>
+                                    <span className="label">Title:</span>
                                     <span className="value">{meeting.topic.title}</span>
                                 </div>
                                 <div className="detail-row">
@@ -133,14 +144,19 @@ const MeetingDetailPage = () => {
                                     <span className="label">Remark:</span>
                                     <span className="value">{meeting.topic.remark}</span>
                                 </div>
-                                <div className="detail-row">
-                                    <span className="label">Branch:</span>
-                                    <span className="value">{meeting.companyBranch.name}</span>
-                                </div>
                             </>
                         )}
                         {activeTab === 'suggest' && suggestBy && renderUserInfo(suggestBy)}
-                        {activeTab === 'evaluate' && evaluteBy && renderUserInfo(evaluteBy)}
+                    {activeTab === 'evaluate' && evaluteBy && renderUserInfo(evaluteBy)}
+                    </div>
+                </div>
+
+                <div className="feedback-section">
+                    <h2 className="section-title">FeedBack</h2>
+                    <div className="feedback-list">
+                        {feedbacks.map((fb) => (
+                            <FeedBackCard key={fb.id} feedback={fb} />
+                        ))}
                     </div>
                 </div>
             </div>

--- a/OpenTalk_FE/src/pages/MeetingListPage.jsx
+++ b/OpenTalk_FE/src/pages/MeetingListPage.jsx
@@ -21,12 +21,11 @@ const MeetingListPage = () => {
   const [branches, setBranches] = useState(mockBranches);
   const [searchTerm, setSearchTerm] = useState('');
   const [branchFilter, setBranchFilter] = useState('');
-  const [activeTab, setActiveTab] = useState('inactive');
+  const [activeTab, setActiveTab] = useState('notScheduled');
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 8;
 
   const tabs = [
-    { id: 'inactive', label: 'Inactive' },
     { id: 'completed', label: 'History' },
     { id: 'waitingHost', label: 'Waiting Host To Register' },
     { id: 'notScheduled', label: 'Upcoming' },
@@ -76,9 +75,9 @@ const MeetingListPage = () => {
     const meetingDate = new Date(m.scheduledDate);
     const diffDays = Math.floor((meetingDate - now) / (1000 * 60 * 60 * 24));
 
+    if (m.status === OpenTalkMeetingStatus.INACTIVE) return false;
+
     switch (activeTab) {
-      case 'inactive':
-        return m.status === OpenTalkMeetingStatus.INACTIVE;
       case 'completed':
         return m.status === OpenTalkMeetingStatus.COMPLETED;
       case 'waitingHost':

--- a/OpenTalk_FE/src/pages/styles/MeetingDetailPage.css
+++ b/OpenTalk_FE/src/pages/styles/MeetingDetailPage.css
@@ -111,7 +111,29 @@
     color: #9ca3af;
 }
 
-.main-content {
+.meeting-highlight {
+    margin-bottom: 24px;
+}
+
+.meeting-name {
+    text-align: center;
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 16px;
+}
+
+.section-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: #111827;
+    margin-bottom: 16px;
+}
+
+.host-section .section-title {
+    text-align: center;
+}
+
+.topic-content {
     background: white;
     border-radius: 12px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
@@ -169,6 +191,20 @@
 .link {
     color: #0369a1;
     text-decoration: underline;
+}
+
+.feedback-section {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    padding: 24px;
+    grid-column: span 2;
+}
+
+.feedback-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
 }
 
 @media (max-width: 1024px) {


### PR DESCRIPTION
## Summary
- remove Inactive tab from MeetingListPage
- filter out inactive meetings
- redesign MeetingDetailPage profile section to highlight meeting info
- rename main content section to Topic content and show topic general info
- add feedback section with new FeedBackCard component
- provide mock feedback data

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876360b3ab8832b9fcea0052c65318d