### PR TITLE
Add feedback input card

### DIFF
--- a/OpenTalk_FE/src/components/feedBackCard/FeedBackCardInput.css
+++ b/OpenTalk_FE/src/components/feedBackCard/FeedBackCardInput.css
@@ -1,0 +1,38 @@
+.feedback-input {
+    align-items: flex-start;
+}
+
+.feedback-textarea {
+    width: 100%;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    padding: 8px;
+    font-size: 14px;
+    resize: vertical;
+    margin-bottom: 8px;
+    color: #374151;
+}
+
+.feedback-rating.selectable svg {
+    cursor: pointer;
+    color: #d1d5db;
+}
+
+.feedback-rating.selectable .filled {
+    color: #f59e0b;
+}
+
+.feedback-send {
+    margin-top: 8px;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 8px;
+    background-color: #10b981;
+    color: white;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.feedback-send:hover {
+    background-color: #059669;
+}

--- a/OpenTalk_FE/src/components/feedBackCard/FeedBackCardInput.jsx
+++ b/OpenTalk_FE/src/components/feedBackCard/FeedBackCardInput.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { FaStar } from 'react-icons/fa';
+import './FeedBackCardInput.css';
+
+const FeedBackCardInput = ({ onSubmit }) => {
+    const [comment, setComment] = useState('');
+    const [rating, setRating] = useState(0);
+
+    const handleStarClick = (index) => {
+        setRating(index + 1);
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (onSubmit) {
+            onSubmit({ comment, rating });
+        }
+        setComment('');
+        setRating(0);
+    };
+
+    return (
+        <form className="feedback-card feedback-input" onSubmit={handleSubmit}>
+            <img src="/placeholder.svg" alt="avatar" className="feedback-avatar" />
+            <div className="feedback-info">
+                <textarea
+                    className="feedback-textarea"
+                    value={comment}
+                    onChange={(e) => setComment(e.target.value)}
+                    placeholder="Write your feedback..."
+                    rows={3}
+                />
+                <div className="feedback-rating selectable">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                        <FaStar
+                            key={i}
+                            className={i < rating ? 'filled' : ''}
+                            onClick={() => handleStarClick(i)}
+                        />
+                    ))}
+                </div>
+                <button type="submit" className="feedback-send">
+                    Send Feedback
+                </button>
+            </div>
+        </form>
+    );
+};
+
+export default FeedBackCardInput;


### PR DESCRIPTION
## Summary
- create `FeedBackCardInput` component for entering feedback
- add accompanying CSS

## Testing
- `npm run lint` *(fails: 146 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e00eaf84c832ba7e880d197a03a22