### PR TITLE
[Fix] Screen - Meeting card width

### DIFF
--- a/OpenTalk_FE/src/components/meetingCard/meetingCard/MeetingCard.css
+++ b/OpenTalk_FE/src/components/meetingCard/meetingCard/MeetingCard.css
@@ -4,6 +4,8 @@
     border-radius: 16px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     width: 100%;
+    max-width: 400px;
+    margin: 0 auto;
     font-family: Arial, sans-serif;
     cursor: pointer;
     display: flex;

--- a/OpenTalk_FE/src/pages/styles/MeetingListPage.css
+++ b/OpenTalk_FE/src/pages/styles/MeetingListPage.css
@@ -97,6 +97,7 @@
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: 16px;
     margin-bottom: 32px;
+    justify-items: center;
 }
 
 .pagination {
@@ -228,6 +229,7 @@
     .meeting-list-container {
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
         gap: 20px;
+        justify-items: center;
     }
 }
 
@@ -262,6 +264,7 @@
     .meeting-list-container {
         grid-template-columns: 1fr;
         gap: 16px;
+        justify-items: center;
     }
     
     .pagination {


### PR DESCRIPTION
## Summary
- limit width of meeting cards
- center meeting cards in list

## Testing
- `npm run lint` *(fails: no-unused-vars, process not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687fa0c274c4832bbbacbcb46a3f69ca