### PR TITLE
Adjust meeting list alignment

### DIFF
--- a/OpenTalk_FE/src/components/meetingCard/meetingCard/MeetingCard.css
+++ b/OpenTalk_FE/src/components/meetingCard/meetingCard/MeetingCard.css
@@ -5,7 +5,7 @@
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     width: 100%;
     max-width: 400px;
-    margin: 0 auto;
+    margin: 0;
     font-family: Arial, sans-serif;
     cursor: pointer;
     display: flex;

--- a/OpenTalk_FE/src/pages/styles/MeetingListPage.css
+++ b/OpenTalk_FE/src/pages/styles/MeetingListPage.css
@@ -97,7 +97,7 @@
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: 16px;
     margin-bottom: 32px;
-    justify-items: center;
+    justify-items: start;
 }
 
 .pagination {
@@ -229,7 +229,7 @@
     .meeting-list-container {
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
         gap: 20px;
-        justify-items: center;
+        justify-items: start;
     }
 }
 
@@ -264,7 +264,7 @@
     .meeting-list-container {
         grid-template-columns: 1fr;
         gap: 16px;
-        justify-items: center;
+        justify-items: start;
     }
     
     .pagination {


### PR DESCRIPTION
## Summary
- keep meeting cards aligned to the left
- prevent MeetingCard from centering itself

## Testing
- `npm run lint` *(fails: 153 errors, 24 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687fa351a4ac832bbdfbb4be6a78afba