### PR TITLE
[Fix] MeetingList - reduce spacing between cards

### DIFF
--- a/OpenTalk_FE/src/components/meetingCard/meetingCard/MeetingCard.css
+++ b/OpenTalk_FE/src/components/meetingCard/meetingCard/MeetingCard.css
@@ -4,7 +4,7 @@
     border-radius: 16px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
     width: 100%;
-    max-width: 400px;
+    /* Allow the card to fully occupy the grid column to avoid large gaps */
     margin: 0;
     font-family: Arial, sans-serif;
     cursor: pointer;


### PR DESCRIPTION
### Summary
Reduce excessive whitespace between MeetingCard items by allowing the cards to occupy the full grid column width.

### Testing
- `npm run lint` *(fails: many unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fa4fb0418832b8fd47eaffd9cb66e